### PR TITLE
minutes 2025 06 19

### DIFF
--- a/meetings/2025-06-19.md
+++ b/meetings/2025-06-19.md
@@ -1,0 +1,62 @@
+# NetworkX Developer Discussions: June 19, 2025
+
+[Previous meeting notes](https://github.com/networkx/archive/tree/main/meetings) are available. 
+Please add News, Discussion and Topics below.
+Meeting link: https://colgate.zoom.us/j/92619161786
+
+## Meeting Info
+- Meeting time Thursdays 12-1 ET (4pm UTC) 
+- [dispatching meeting](https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug) 1st Tuesday of the month 11:30-12:30 ET 
+- [Publicly available analytics for our docs pages](https://views.scientific-python.org/networkx.org)
+
+**In attendance**: Dan, Akshita, Ross, Aditi
+
+## Upcoming meetings and events
+- Scipy 2025 (Erik & Ralph talk and poster)
+- EuroSciPy 2025 (18th-22nd August, 2025) : Aditi and Sebastian talk
+
+### Action Items
+- Webpage and translations: Jarrod held off from updating the webpage though. He says "But the translations on the main page look like they are going to make releases more difficult if we want to keep the translations up to date." Where do we stand on this issue? Are there discussions on the website repo PRs or Issues that discuss how to update the webpages?
+    - Jarrod updated the webpage to v3.5 without the translations.
+    - Let's continue the discussion of how to maintain translations. Numpy has English for v2.2 while translations are only for v1.26.
+- [PR 8112](https://github.com/networkx/networkx/pull/8112) implements a numpy version of tournament.is_reachable. 
+    - Should we deprecate the old version? (Are all results the same with the two methods?)
+    - Should we keep a pure python version around for when numpy is not available? Proposal:
+        - keep the old purepython code in a private function `_is_reachable_pure_python`. At the point of numpy import use try/except and upon except call the private python version. 
+        - add heatmap in PR comments?
+- `iplotx` (Fabio Zanini [package for drawing igraph and NetworkX graphs](https://github.com/fabilab/iplotx)) 
+    - Updates:
+        - supports 
+        - [Gallery now includes](https://iplotx.readthedocs.io/en/latest/gallery/index.html) post-draw editing, "ports" (cardinal directions for the edges), animations, per-vertex and per-edge styling using flexible syntax, consistent scaling with DPI (e.g. retina screens, PNG files), controllable tension and loop tension, etc. It also supports color mapping smoothly (easier than networkx, for instance).
+        - A more [comprehensive feature list](https://iplotx.readthedocs.io/en/latest/index.html#features) says that it all works equally well for networks from networkx, igraph, and four libraries that deal with trees (skbio, Biopython, cogent3, and ETE4). The code has 40+ unit tests, pylint 9.13 out of 10, has very few flake8 warnings, uses type hints throughout and is well documented.
+    - **request for networkx**: Ideas about how to interact positively to help user experience?
+        -  we can add documentation that points to iplotx. 
+        -  We probably want to keep basic drawing functions in NetworkX but if iplotx is present, use it instead of the basic functions.  ???
+        -  ideas?
+        -  add iplotx to intersphinx and link our gallery examples to iplotx galleries
+        -  add "see also" sections to the plotting functions (and/or to the drawing rst summary)
+        -  we can improve NetworkX code in the examples within iplotx.
+## Topics
+- [PR 8107](https://github.com/networkx/networkx/pull/8107) linear geometric centralities PR.
+- [Tree Centroid 8089](https://github.com/networkx/networkx/pull/8089) We have Tree Center (recently added). The centroid is the same as the barycenter. So this is a faster version of barycenter that works for trees. 
+    - Should call this from the general barycenter code after checking if input is a tree? (Yes)
+    - name for this function: if we keep it in the tree namespace, we can assume it is a tree input graph. (2 ways to access the code -- barycenter itself with a tree input, and `tree_centroid` within the tree namespace)
+- pytest-mpl Should we turn it on generally? (probably yes)
+
+## Old Topics
+- dispatching of classes. Lets look at the [PR 7760](https://github.com/networkx/networkx/pull/7760) and whether this is something we want to do.
+    - Would be used by arrangoDB and nx-cugraph
+    - if its useful for backend users/consumers and it doesn't impact other users (opt-in, etc). 
+- chordal graphs, elimination orders, etc.
+    - what is alpha used for other than an ordering. Why not return a list for the ordering?
+    - Alpha dict is supposed to be a perfect elimination ordering. We will remove the alpha feature and just return the ordering as a list.
+- Benchmarking: Building off what Derek put together.
+    - pytest.benchmark vs asv for benchmarks? Are there better tools. 
+        - What did Derek use in the end? Are there tools within that we could build on.
+    - Three aspects to benchmarking:
+        - presentation of results
+        - running and data storage (ascii/csv/json, etc)
+        - authoring (which datasets as well as parameters of the functions)
+    - Can we put together a set of functions and datasets?
+        - Create a NetworkX suite of graph benchmarks
+- Manually replace functions with useful errormessages by tweaking `getattr`. Let's try to do this with removed functions that have replacements. (Add docs for developers about this to the deprecation handling part of dev docs.)


### PR DESCRIPTION
- Add 2025-03-07 meeting notes
- Add 2025-03-14 meeting notes
- Add March 21st 2025 meeting notes.
- Add 2025-03-28 meeting notes
- Add 2025-04-04 meeting notes
- Add dispatch meeting notes for 2023, 2024, 2025
- Add link to archived notes
- Oops: add `.md` file extension to dispatching notes
- Add 2025-04-11 meeting notes
- Add 2025-04-18 meeting notes
- Add 2025-04-25 meeting notes
- Add 2025-05-02 meeting notes
- Add 2025-05-09 meeting notes
- Create 2024.md
- Add 2025-05-16 meeting notes
- Add 2025-05-23 meeting notes
- Add 2025-05-29 meeting notes
- Add 2025-06-05 meeting notes
- Add 2025-06-12 meeting notes
- Add 2025-06-19 meeting notes
