### PR TITLE
minutes 2025 07 03

### DIFF
--- a/meetings/2025-07-03.md
+++ b/meetings/2025-07-03.md
@@ -1,0 +1,84 @@
+# NetworkX Developer Discussions: July 3, 2025
+
+[Previous meeting notes](https://github.com/networkx/archive/tree/main/meetings) are available. 
+Please add News, Discussion and Topics below.
+Meeting link: https://colgate.zoom.us/j/92619161786
+
+## Meeting Info
+- Meeting time Thursdays 12-1 ET (4pm UTC) 
+- [dispatching meeting](https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug) 1st Tuesday of the month 11:30-12:30 ET 
+- [Publicly available analytics for our docs pages](https://views.scientific-python.org/networkx.org)
+
+**In attendance**: Dan, Ross, Mridul, Rick, Akshita
+
+## Upcoming meetings and events
+- Scipy 2025 (Erik talk)
+- EuroSciPy 2025 (18th-22nd August, 2025) : Aditi and Sebastian talk
+
+## Topics
+
+- SPEC 7: Scientific Python Ecosystem coordination for random number API
+- Walks, trails, and paths in NetworkX
+  * https://github.com/networkx/networkx/pull/8123
+- `is_reachable`: can we construct the `two_neighbor` results without searching the entire graph?
+  * https://github.com/networkx/networkx/pull/8112
+- Strong perfect graph theorem
+  * https://github.com/networkx/networkx/pull/8111
+- Corollary: minimum-len cycle detection - anyone know of any algorithms?
+  * https://github.com/networkx/networkx/issues/8128
+- Minute detail in FR implementation leads to interesting visualizations+discussion about force-directed layouts!
+  * https://github.com/networkx/networkx/issues/8113
+  * this animation might be a good gallery example
+  * also good mention in the spring_layout docs that increasing the number of iterations can help a lot with layout quality for larger graphs.
+- [PR 8107](https://github.com/networkx/networkx/pull/8107) linear geometric centralities PR.
+- [Tree Centroid 8089](https://github.com/networkx/networkx/pull/8089) We have Tree Center (recently added). The centroid is the same as the barycenter. So this is a faster version of barycenter that works for trees. 
+    - Should call this from the general barycenter code after checking if input is a tree? (Yes)
+    - name for this function: if we keep it in the tree namespace, we can assume it is a tree input graph. (2 ways to access the code -- barycenter itself with a tree input, and `tree_centroid` within the tree namespace)
+- pytest-mpl Should we turn it on generally? (probably yes)
+- Review PRs in reverse chronological order. 
+
+### Action Items
+- Webpage and translations: Jarrod held off from updating the webpage though. He says "But the translations on the main page look like they are going to make releases more difficult if we want to keep the translations up to date." Where do we stand on this issue? Are there discussions on the website repo PRs or Issues that discuss how to update the webpages?
+    - Jarrod updated the webpage to v3.5 without the translations.
+    - Let's continue the discussion of how to maintain translations. Numpy has English for v2.2 while translations are only for v1.26.
+- [PR 8112](https://github.com/networkx/networkx/pull/8112) implements a numpy version of tournament.is_reachable. 
+    - Should we deprecate the old version? (Are all results the same with the two methods?)
+    - Should we keep a pure python version around for when numpy is not available? Proposal:
+        - keep the old purepython code in a private function `_is_reachable_pure_python`. At the point of numpy import use try/except and upon except call the private python version. 
+        - add heatmap in PR comments?
+- `iplotx` (Fabio Zanini [package for drawing igraph and NetworkX graphs](https://github.com/fabilab/iplotx)) 
+    - Updates:
+        - Fabio is encouraged by our feedback and is close to switching to focus intently on docs and tests. **Summary of following quote:** Create issues on iplotx for any suggestions so he can remember them.
+        > Your help is much appreciated and those are awesome suggestions. I think as things stand now, I'm open for all channels of feedback, but perhaps when things get technical GitHub issues are the easiest.
+        > 
+        > For instance, if you guys have suggestions for ways to handle list-like styles and convert to dicts, it'd be great to have an open issue to track that.
+        > 
+        > Another example, together with forward links in your docs to iplotx, I could easily add backlinks to networkx same way (e.g. to help users understand what those dict-like node attribute objects are). If there are requests in that directions, having an open issue/ticket would help me remember it's a TODO.
+        > 
+        > From my end, I'm wrapping up some polishing on label alignment and rotation which is finnicky in matplotlib (codeword: "anchored rotation") but after that I'll go into test + documentation mode: adding pages to explain the spirit, use cases, functions, adding coverage tests, and generally try to break iplotx in as many ways as possible to build robustness.
+        > 
+        > If any of you guys start using it for tests or production and has requests, please open issues and I'll be happy to address them. I'm open to PR as well, of course, if anyone wants to wet their feet themselves!
+        > 
+        > I have more plans down the road but for now I think knowing you guys find it promising and useful is really satisfying and hopefully now I can make it robust and reliable.
+
+        - take a look at [the "styles" docs](https://iplotx.readthedocs.io/en/latest/style.html)
+        - [Gallery](https://iplotx.readthedocs.io/en/latest/gallery/index.html) 
+
+
+## Old Topics
+- dispatching of classes. Lets look at the [PR 7760](https://github.com/networkx/networkx/pull/7760) and whether this is something we want to do.
+    - Would be used by arrangoDB and nx-cugraph
+    - if its useful for backend users/consumers and it doesn't impact other users (opt-in, etc). 
+- chordal graphs, elimination orders, etc.
+    - what is alpha used for other than an ordering. Why not return a list for the ordering?
+    - Alpha dict is supposed to be a perfect elimination ordering. We will remove the alpha feature and just return the ordering as a list.
+- Benchmarking: Building off what Derek put together.
+    - pytest.benchmark vs asv for benchmarks? Are there better tools. 
+        - What did Derek use in the end? Are there tools within that we could build on.
+    - Three aspects to benchmarking:
+        - presentation of results
+        - running and data storage (ascii/csv/json, etc)
+        - authoring (which datasets as well as parameters of the functions)
+    - Can we put together a set of functions and datasets?
+        - Create a NetworkX suite of graph benchmarks
+- Manually replace functions with useful errormessages by tweaking `getattr`. Let's try to do this with removed functions that have replacements. (Add docs for developers about this to the deprecation handling part of dev docs.)


### PR DESCRIPTION
- Add 2025-03-07 meeting notes
- Add 2025-03-14 meeting notes
- Add March 21st 2025 meeting notes.
- Add 2025-03-28 meeting notes
- Add 2025-04-04 meeting notes
- Add dispatch meeting notes for 2023, 2024, 2025
- Add link to archived notes
- Oops: add `.md` file extension to dispatching notes
- Add 2025-04-11 meeting notes
- Add 2025-04-18 meeting notes
- Add 2025-04-25 meeting notes
- Add 2025-05-02 meeting notes
- Add 2025-05-09 meeting notes
- Create 2024.md
- Add 2025-05-16 meeting notes
- Add 2025-05-23 meeting notes
- Add 2025-05-29 meeting notes
- Add 2025-06-05 meeting notes
- Add 2025-06-12 meeting notes
- Add 2025-07-03 meeting notes
